### PR TITLE
Allow child view controllers to modify the state of parent view controller

### DIFF
--- a/ShowMeAds/Controllers/AdCollectionViewController.swift
+++ b/ShowMeAds/Controllers/AdCollectionViewController.swift
@@ -136,6 +136,10 @@ extension AdCollectionViewController {
             noFavoritesLabel.centerYAnchor.constraint(equalTo: collectionView.centerYAnchor, constant: -.veryLargeSpacing),
         ])
     }
+    
+    private func removeNoFavoritesLabel() {
+        noFavoritesLabel.removeFromSuperview()
+    }
 }
 
 // MARK: - Private selector methods
@@ -159,11 +163,8 @@ extension AdCollectionViewController {
                 }
             })
         case false:
-            fetchAds(endpoint: .remote, onCompletion: { [weak self] in
-                DispatchQueue.main.async {
-                    self?.refreshControl.endRefreshing()
-                }
-            })
+            refreshControl.endRefreshing()
+            transition(to: .loading)
         }
     }
 }
@@ -176,7 +177,7 @@ extension AdCollectionViewController {
         case true:
             showNoFavoritesLabel()
         default:
-            noFavoritesLabel.removeFromSuperview()
+            removeNoFavoritesLabel()
         }
         return ads.count
     }

--- a/ShowMeAds/Controllers/AdCollectionViewController.swift
+++ b/ShowMeAds/Controllers/AdCollectionViewController.swift
@@ -77,12 +77,6 @@ class AdCollectionViewController: UICollectionViewController {
         parent?.navigationItem.rightBarButtonItem = UIBarButtonItem.init(customView: offlineSwitch)
     }
     
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-        parent?.navigationItem.leftBarButtonItem = nil
-        parent?.navigationItem.rightBarButtonItem = nil
-    }
-    
     required init?(coder aDecoder: NSCoder) {
         fatalError("Not implemented")
     }
@@ -114,10 +108,20 @@ extension AdCollectionViewController {
     }
     
     private func render(_ error: Error) {
-        guard let state = parent as? AdStateViewController else { return }
-        state.transition(to: .error)
+        transition(to: .error)
     }
     
+    private func transition(to newState: State) {
+        guard let currentState = parent as? AdStateViewController else { return }
+        switch newState {
+        case .error:
+            currentState.transition(to: .error)
+        case .loading:
+            currentState.transition(to: .loading)
+        default:
+            break
+        }
+    }
 }
 
 // MARK: - Private methods for UI modifications
@@ -134,7 +138,7 @@ extension AdCollectionViewController {
     }
 }
 
-// MARK: - Selector methods
+// MARK: - Private selector methods
 
 extension AdCollectionViewController {
     @objc func didTapOfflineMode() {
@@ -142,8 +146,7 @@ extension AdCollectionViewController {
         case true:
             fetchAds(endpoint: .favorited, onCompletion: nil)
         case false:
-            noFavoritesLabel.removeFromSuperview()
-            fetchAds(endpoint: .remote, onCompletion: nil)
+            transition(to: .loading)
         }
     }
     

--- a/ShowMeAds/Controllers/AdErrorViewController.swift
+++ b/ShowMeAds/Controllers/AdErrorViewController.swift
@@ -54,23 +54,16 @@ class AdErrorViewController: UIViewController {
     }
     
     @objc private func didTapRefreshButton(sender: UIButton) {
-        UIButton.animate(withDuration: 0.1, animations: {
+        UIButton.animate(withDuration: 0.1, animations: { [weak self] in
             sender.transform = CGAffineTransform(scaleX: 0.90, y: 0.90)
-        }) { (didAnimate) in
-            sender.transform = CGAffineTransform.identity
-        }
-        
-        AdsFacade.shared.fetchAds(endpoint: .remote) { [weak self] (result) in
-            switch result {
-            case .success(let ads):
+            
+            DispatchQueue.main.async {
                 guard let state = self?.parent as? AdStateViewController else { return }
-                let vc = AdCollectionViewController.init(ads)
-                DispatchQueue.main.async {
-                    state.transition(to: .loaded(vc))
-                }
-            case .error(_):
-                print("Still offline - No state has changed.")
+                state.transition(to: .loading)
             }
+            
+        }) { (_) in
+            sender.transform = CGAffineTransform.identity
         }
     }
 }

--- a/ShowMeAds/Controllers/AdStateViewController.swift
+++ b/ShowMeAds/Controllers/AdStateViewController.swift
@@ -27,23 +27,32 @@ class AdStateViewController: UIViewController {
     override func viewWillLayoutSubviews() {
         super.viewWillLayoutSubviews()
         guard let state = state else { return }
-        
-        switch state {
-        case .loading:
-            AdsFacade.shared.fetchAds(endpoint: .remote) { [weak self] (result) in
-                switch result {
-                case .error(let error):
-                    DispatchQueue.main.async {
-                        self?.render(error)
-                    }
-                case .success(let ads):
-                    DispatchQueue.main.async {
-                        self?.render(ads)
-                    }
+        guard case State.loading = state else { return }
+    
+        switch Reachability.isConnectedToNetwork() {
+        case true:
+            fetchAds(endpoint: .remote)
+        case false:
+            fetchAds(endpoint: .database)
+        }
+    }
+}
+
+// MARK: Method to fetch ads from any given endpoint
+
+extension AdStateViewController {
+    private func fetchAds(endpoint: EndpointType) {
+        AdsFacade.shared.fetchAds(endpoint: endpoint) { [weak self] (result) in
+            switch result {
+            case .error(let error):
+                DispatchQueue.main.async {
+                    self?.render(error)
+                }
+            case .success(let ads):
+                DispatchQueue.main.async {
+                    self?.render(ads)
                 }
             }
-        default:
-            break
         }
     }
 }
@@ -74,7 +83,7 @@ extension AdStateViewController {
     }
 }
 
-// MARK: Methods for rendering child controllers
+// MARK: Render child controllers given argument
 
 extension AdStateViewController {
     private func render(_ ads: [AdItem]) {
@@ -86,4 +95,5 @@ extension AdStateViewController {
         transition(to: .error)
     }
 }
+
 

--- a/ShowMeAds/Controllers/AdStateViewController.swift
+++ b/ShowMeAds/Controllers/AdStateViewController.swift
@@ -22,24 +22,37 @@ class AdStateViewController: UIViewController {
         if state == nil {
             transition(to: .loading)
         }
+    }
+    
+    override func viewWillLayoutSubviews() {
+        super.viewWillLayoutSubviews()
+        guard let state = state else { return }
         
-        AdsFacade.shared.fetchAds(endpoint: .remote) { [weak self] (result) in
-            switch result {
-            case .error(let error):
-                DispatchQueue.main.async {
-                    self?.render(error)
-                }
-            case .success(let ads):
-                DispatchQueue.main.async {
-                    self?.render(ads)
+        switch state {
+        case .loading:
+            AdsFacade.shared.fetchAds(endpoint: .remote) { [weak self] (result) in
+                switch result {
+                case .error(let error):
+                    DispatchQueue.main.async {
+                        self?.render(error)
+                    }
+                case .success(let ads):
+                    DispatchQueue.main.async {
+                        self?.render(ads)
+                    }
                 }
             }
+        default:
+            break
         }
     }
 }
 
+// MARK: Methods for transitioning between states
+
 extension AdStateViewController {
     func transition(to newState: State) {
+
         shownViewController?.remove()
         
         let vc = viewController(for: newState)
@@ -60,6 +73,8 @@ extension AdStateViewController {
         }
     }
 }
+
+// MARK: Methods for rendering child controllers
 
 extension AdStateViewController {
     private func render(_ ads: [AdItem]) {


### PR DESCRIPTION
- Child view controllers can modify the state of the parent to `loading` and `error`
- The parent view controller will always check the current state in the `willLayoutSubviews` method. If the current state is `loading` it will issue a new request to the server.