### PR TITLE
Always show ads stored in core data

### DIFF
--- a/ShowMeAds/Controllers/AdCollectionViewController.swift
+++ b/ShowMeAds/Controllers/AdCollectionViewController.swift
@@ -99,18 +99,13 @@ extension AdCollectionViewController {
         case true:
             adService.fetchFavoritedAds()
         case false:
-            adService.fetchAds()
+            adService.fetchAds(endpoint: .database)
         }
     }
     
     @objc func pullToRefresh() {
         refreshControl.endRefreshing()
-        switch offlineSwitch.isOn {
-        case true:
-            adService.fetchFavoritedAds()
-        case false:
-            adService.fetchAds()
-        }
+        adService.fetchAds(endpoint: .database)
     }
 }
 

--- a/ShowMeAds/Controllers/AdErrorViewController.swift
+++ b/ShowMeAds/Controllers/AdErrorViewController.swift
@@ -76,7 +76,7 @@ extension AdErrorViewController {
     @objc private func didTapRefreshButton(sender: UIButton) {
         UIButton.animate(withDuration: 0.1, animations: { [weak self] in
             sender.transform = CGAffineTransform(scaleX: 0.90, y: 0.90)
-            self?.adService.fetchAds()
+            self?.adService.fetchAds(endpoint: .remote)
         }) { (_) in
             sender.transform = CGAffineTransform.identity
         }

--- a/ShowMeAds/Controllers/AdStateContainerController.swift
+++ b/ShowMeAds/Controllers/AdStateContainerController.swift
@@ -25,7 +25,12 @@ class AdStateContainerController: UIViewController {
         super.viewDidLoad()
         adService.dataSource = self
         
+        switch adService.hasSavedAds() {
+        case true:
+            adService.fetchAds(endpoint: .database)
+        case false:
             transition(to: .loading)
+            adService.fetchAds(endpoint: .remote)
         }
     }
     

--- a/ShowMeAds/Services/AdService.swift
+++ b/ShowMeAds/Services/AdService.swift
@@ -13,7 +13,6 @@ public enum EndpointType {
 }
 
 public protocol AdServiceDataSource: NSObjectProtocol {
-    func willUpdate()
     func didUpdate(ads: [AdItem])
 }
 
@@ -33,7 +32,7 @@ final class AdService {
     init(_ networkService: AdNetworkService, _ persistenceService: AdPersistenceService) {
         self.networkService = networkService
         self.persistenceService = persistenceService
-        
+
         scheduleRequest()
     }
 }
@@ -41,15 +40,50 @@ final class AdService {
 // MARK: Public methods
 
 extension AdService {
-    public func fetchAds() {
-        dataSource?.willUpdate()
-        requestAds()
+    
+    /// Returns true if there's any ads saved to core data, false otherwise
+    
+    public func hasSavedAds() -> Bool {
+        let ads = persistenceService.fetch(where: nil)
+        switch ads.count {
+        case let count where count > 0:
+            return true
+        default:
+            return false
+        }
     }
+    
+    // Fetches ads from any given `EndpointType`
+    // After retriving the ads it calls the `didUpdate` to notify the implementing delegate
+    
+    public func fetchAds(endpoint: EndpointType) {
+        switch endpoint {
+        case .remote:
+            networkService.fetch(completionHandler: { [weak self] (response) in
+                guard let strongSelf = self else { return }
+                switch response {
+                case .error(_):
+                    let ads = strongSelf.persistenceService.fetch(where: nil)
+                    self?.dataSource?.didUpdate(ads: ads)
+                case .success(let ads):
+                    let filteredAds = strongSelf.persistenceService.updateOrInsert(ads)
+                    self?.dataSource?.didUpdate(ads: filteredAds)
+                }
+            })
+        case .database:
+            let ads = persistenceService.fetch(where: nil)
+            self.dataSource?.didUpdate(ads: ads)
+        }
+    }
+    
+    // Fetches the ads from Core Data that has been favorited
     
     public func fetchFavoritedAds() {
         let ads = persistenceService.fetch(where: NSPredicate(format: "isFavorited == true"))
         dataSource?.didUpdate(ads: ads)
     }
+    
+    // Update the provided fields for any given `Ad` entity in Core Data
     
     public func update(ad: AdItem, price: Int32? = nil, location: String? = nil,
                        title: String? = nil, isFavorited: Bool? = nil) {
@@ -63,25 +97,12 @@ extension AdService {
 extension AdService {
     
     /// Sends a GET request to the backend every 60 seconds.
+    
     private func scheduleRequest() {
         let scheduledTime = DispatchTime.now() + 60
         DispatchQueue.main.asyncAfter(deadline: scheduledTime) { [weak self] in
-            self?.requestAds()
+            self?.fetchAds(endpoint: .remote)
             self?.scheduleRequest()
         }
-    }
-    
-    private func requestAds() {
-        networkService.fetch(completionHandler: { [weak self] (response) in
-            guard let strongSelf = self else { return }
-            switch response {
-            case .error(_):
-                let ads = strongSelf.persistenceService.fetch(where: nil)
-                self?.dataSource?.didUpdate(ads: ads)
-            case .success(let ads):
-                let filteredAds = strongSelf.persistenceService.updateOrInsert(ads)
-                self?.dataSource?.didUpdate(ads: filteredAds)
-            }
-        })
     }
 }


### PR DESCRIPTION
- Don’t show the loading state during startup
- Defaults to always show the data that is stored in core data
- Updates both the ads stored in core data and in-memory cache in intervals.